### PR TITLE
Fix npm install peer dependency conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "copyfiles": "^2.4.1",
     "rimraf": "^6.1.3",
     "ts-node": "^10.9.2",
-    "typescript": "^6.0.2"
+    "typescript": "^5.9.3"
   },
   "scripts": {
     "start": "ts-node ./src/server.ts",


### PR DESCRIPTION
## Note
Issue can be closed/ignored, since typescript 5 is only optional declared, but good to have an eye on it

## Summary
Pin TypeScript to the current v5 line so npm install resolves cleanly with Mirador's dependency tree.

## Issue
npm install fails with ERESOLVE unable to resolve dependency tree because this repo requested typescript@^6, while mirador@4.0.0 brings in react-i18next@15.7.4, which still declares an optional peer on typescript@^5.

## Fix
Change the dev dependency from typescript@^6.0.2 to typescript@^5.9.3.

## Why this is safe
The project uses TypeScript only as a dev/build dependency, and the existing toolchain is compatible with TypeScript 5.