### PR TITLE
Add Dependabot build workflow

### DIFF
--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -1,0 +1,33 @@
+name: Dependabot Build Check
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build project
+        run: pnpm build


### PR DESCRIPTION
## Summary
Add a GitHub Actions workflow that runs on Dependabot pull requests and verifies the project still installs and builds.

## What it does
- triggers on pull requests to master
- only runs when the PR author is dependabot[bot]
- installs dependencies with pnpm using the committed lockfile
- runs pnpm build to catch compile and build regressions

## Why
This gives Dependabot updates an automatic compile/build check before merge without affecting unrelated pull requests.