### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.git
+.gitignore
+.DS_Store
+npm-debug.log
+pnpm-debug.log
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# Shared base image for all stages. We keep Node 22 to match the project setup.
+FROM node:22-bookworm-slim AS base
+
+WORKDIR /app
+
+# Enable pnpm via Corepack so we can use the repo's existing pnpm lockfile.
+RUN corepack enable
+
+# Install all dependencies once so the build stage has everything it needs.
+FROM base AS deps
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Build the TypeScript app and copy static assets into dist/.
+FROM deps AS build
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN pnpm build
+
+# Create a production-only node_modules tree for the final runtime image.
+FROM base AS prod-deps
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --prod --frozen-lockfile
+
+# Final image: only the compiled app and runtime dependencies.
+FROM node:22-bookworm-slim AS runtime
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3333
+
+# The app serves viewer assets from node_modules at runtime, so we copy them in.
+COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY package.json ./
+
+EXPOSE 3333
+
+# Start the compiled server.
+CMD ["node", "dist/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Shared base image for all stages. We keep Node 22 to match the project setup.
+# Shared base image for all stages. Built on debian 12 Bookworm. We keep Node 22 to match the project setup.
 FROM node:22-bookworm-slim AS base
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project can also run in Docker.
 1. Copy `env.example` to `.env` if you want to customize the port
 2. Build and start the container:
    ```bash
-   docker compose up --build
+   docker-compose up --build
    ```
 3. Open `http://localhost:3333`
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ It contains test cases of Image API (v2 and v3), Presentation API (v2 and v3) ab
 4. ```yarn install``` or ```npm install```
 5. ```yarn run start``` or  ```npm run start```
 
+## Docker
+
+This project can also run in Docker.
+
+1. Copy `env.example` to `.env` if you want to customize the port
+2. Build and start the container:
+   ```bash
+   docker compose up --build
+   ```
+3. Open `http://localhost:3333`
+
+To stop the container:
+
+```bash
+docker compose down
+```
+
 ## Demo
 
 https://iiif-testing.sozialarchiv.ch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  test-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "${PORT:-3333}:3333"
+    environment:
+      NODE_ENV: ${NODE_ENV:-production}
+      PORT: ${PORT:-3333}

--- a/env.example
+++ b/env.example
@@ -1,2 +1,2 @@
-NODE_ENV=development
-IIIF_TEST_SERVER_PORT=3333
+NODE_ENV=production
+PORT=3333

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "start": "ts-node ./src/server.ts",
+    "start:prod": "node ./dist/server.js",
     "watch": "node --watch -r ts-node/register ./src/server.ts",
     "build": "rimraf dist/ && tsc && copyfiles -u 1 \"src/**/*.html\" \"src/**/*.mp3\" \"src/**/*.webm\" \"src/**/*.vtt\" \"src/**/*.mp4\" \"src/**/*.txt\" \"src/**/*.docx\" \"src/**/*.pdf\" \"src/**/*.png\" \"src/**/*.jpg\" \"src/**/*.png\" \"src/**/*.css\" \"src/**/*.svg\" \"src/**/*.js\" \"src/**/*.json\" dist/"
   },


### PR DESCRIPTION
## Summary
Add Docker support for running the IIIF test server in a container.

## What changed
- add a multi-stage Dockerfile for building and running the app
- add docker-compose.yml for local container startup
- add .dockerignore to keep Docker builds lean
- add a production start script in package.json
- align env.example with the actual PORT variable used by the app
- document Docker usage in the README

## Notes
The container keeps runtime node_modules because this app serves viewer assets directly from installed packages.